### PR TITLE
Merge feature/project-templates into main

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: "Create a report to help us improve."
+labels: bug
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Open notebook `{filename}`
+2. Run all cells through `{#}`
+3. See error
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Development Environment (please complete the following information):
+ - OS: [e.g. macOS, Linux]
+ - OS Version: [e.g. Big Sur 11.4, Debian 11]
+ - Python Versions: [i.e. Output of `{conda|mamba} list`]
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: "Suggest an idea for this project."
+labels: enhancement
+---
+
+## Is your feature request related to a problem? Please describe:
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like:
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered:
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context:
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue
+about: "Create a custom issue."
+---
+
+A clear and concise description of what this issue addresses.
+
+### Task list
+* [ ] Short task description
+* [ ] Another short task description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## This PR...
+<!-- Describe WHAT this PR does and WHY it is needed. -->
+
+
+## Checklist
+<!-- Replace `xxxx` with the relevant issue number -->
+- [ ] Closes GH-xxxx
+- [ ] Changes are documented in `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased
   * Analyze ([PR-2])
   * Deliver ([PR-4])
   * Visualize ([PR-3])
+* GitHub pull request and issue templates ([GH-10], [PR-11])
 * Static asset files ([PR-2])
 * Environment files ([PR-2])
 * Community health files ([GH-5], [PR-6])
@@ -37,3 +38,5 @@ Unreleased
 [PR-6]: https://github.com/ReflectiveEarth/reflective-potential/pull/6
 [GH-8]: https://github.com/ReflectiveEarth/reflective-potential/issues/8
 [PR-9]: https://github.com/ReflectiveEarth/reflective-potential/pull/9
+[GH-10]: https://github.com/ReflectiveEarth/reflective-potential/issues/10
+[PR-11]: https://github.com/ReflectiveEarth/reflective-potential/pull/11


### PR DESCRIPTION
## This PR...
<!-- Describe WHAT this PR does and WHY it is needed. -->
Adds Markdown templates for pull requests and issues. This is needed to help contributors provide standard documentation for pull requests, bug reports, feature requests, and other issues.

## Checklist
<!-- Replace `xxxx` with the relevant issue number -->
- [x] Closes GH-10
- [x] Changes are documented in `CHANGELOG.md`