### PR TITLE
Merge bugfix/issue-templates into main

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ---
-name: Custom issue
+name: Other issue
 about: "Create a custom issue."
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Unreleased
   * Analyze ([PR-2])
   * Deliver ([PR-4])
   * Visualize ([PR-3])
-* GitHub pull request and issue templates ([GH-10], [PR-11])
+* GitHub pull request and issue templates ([GH-10], [PR-11], [GH-12], [PR-13])
 * Static asset files ([PR-2])
 * Environment files ([PR-2])
 * Community health files ([GH-5], [PR-6])
@@ -40,3 +40,5 @@ Unreleased
 [PR-9]: https://github.com/ReflectiveEarth/reflective-potential/pull/9
 [GH-10]: https://github.com/ReflectiveEarth/reflective-potential/issues/10
 [PR-11]: https://github.com/ReflectiveEarth/reflective-potential/pull/11
+[GH-12]: https://github.com/ReflectiveEarth/reflective-potential/issues/12
+[PR-13]: https://github.com/ReflectiveEarth/reflective-potential/pull/13


### PR DESCRIPTION
## This PR...
<!-- Describe WHAT this PR does and WHY it is needed. -->
Modifies the name of the custom issue template and disables blank issues. This is necessary to improve the clarity of the issue template chooser.

## Checklist
<!-- Replace `xxxx` with the relevant issue number -->
- [x] Closes GH-12
- [x] Changes are documented in `CHANGELOG.md`
